### PR TITLE
Log Errors, Don't Break

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Implementing this interface should allow an extensible way to `Dump` data wherev
 - [X] Allow upload to `Dynamo`
 - [X] Allow multiclient response handling for `Dynamo` handler
 - [ ] Use a `Scraper` interface instead of a coupling marta client to it
+- [ ] `circuitbreaker` in the worker?
+- [ ] backoff, jitter, retryer on dynamo client
 
 ## Running
 

--- a/pkg/martaapi/client.go
+++ b/pkg/martaapi/client.go
@@ -16,6 +16,7 @@ type ScheduleFinder interface {
 
 type Schedule struct {
 	PrimaryKey     string
+	SortKey        string
 	Destination    string `json:"DESTINATION"`
 	Direction      string `json:"DIRECTION"`
 	EventTime      string `json:"EVENT_TIME"`

--- a/pkg/martaapi/dynamohelpers.go
+++ b/pkg/martaapi/dynamohelpers.go
@@ -16,6 +16,7 @@ func ScheduleToWriteRequest(s Schedule, t string) (*dynamodb.WriteRequest, error
 		return nil, err
 	}
 	s.PrimaryKey = fmt.Sprintf("%s_%s_%s", s.Station, s.Destination, date.Format("2006-01-02"))
+	s.SortKey = fmt.Sprintf("%s_%s", s.EventTime, s.TrainID)
 	s.TTL = time.Now().Add(30 * 24 * time.Hour).Unix()
 	attr, err := dynamodbattribute.MarshalMap(s)
 	if err != nil {

--- a/pkg/worker/client.go
+++ b/pkg/worker/client.go
@@ -84,7 +84,6 @@ func (c ScrapeAndDumpClient) scrapeAndDump(ctx context.Context) error {
 	for _, sd := range c.workList.GetWork() {
 		reader, err := sd.Scraper.FindSchedules(ctx)
 		if err != nil {
-			c.logger.Error(err.Error())
 			return err
 		}
 		defer reader.Close()
@@ -92,7 +91,6 @@ func (c ScrapeAndDumpClient) scrapeAndDump(ctx context.Context) error {
 		path := fmt.Sprintf("%s/%s.json", sd.Scraper.Prefix(), t.Format(time.RFC3339))
 		err = sd.Dumper.Dump(ctx, reader, path)
 		if err != nil {
-			c.logger.Error(err.Error())
 			return err
 		}
 	}

--- a/pkg/worker/client.go
+++ b/pkg/worker/client.go
@@ -72,8 +72,7 @@ func (c ScrapeAndDumpClient) Poll(ctx context.Context, errC chan error) {
 			}
 			err := c.scrapeAndDump(ctx)
 			if err != nil {
-				errC <- err
-				return
+				c.logger.Error(err.Error())
 			}
 			time.Sleep(c.pollTime)
 		}
@@ -86,7 +85,7 @@ func (c ScrapeAndDumpClient) scrapeAndDump(ctx context.Context) error {
 		reader, err := sd.Scraper.FindSchedules(ctx)
 		if err != nil {
 			c.logger.Error(err.Error())
-			continue
+			return err
 		}
 		defer reader.Close()
 		t := time.Now().UTC()
@@ -94,6 +93,7 @@ func (c ScrapeAndDumpClient) scrapeAndDump(ctx context.Context) error {
 		err = sd.Dumper.Dump(ctx, reader, path)
 		if err != nil {
 			c.logger.Error(err.Error())
+			return err
 		}
 	}
 	return nil

--- a/pkg/worker/client.go
+++ b/pkg/worker/client.go
@@ -85,14 +85,15 @@ func (c ScrapeAndDumpClient) scrapeAndDump(ctx context.Context) error {
 	for _, sd := range c.workList.GetWork() {
 		reader, err := sd.Scraper.FindSchedules(ctx)
 		if err != nil {
-			return err
+			c.logger.Error(err.Error())
+			continue
 		}
 		defer reader.Close()
 		t := time.Now().UTC()
 		path := fmt.Sprintf("%s/%s.json", sd.Scraper.Prefix(), t.Format(time.RFC3339))
 		err = sd.Dumper.Dump(ctx, reader, path)
 		if err != nil {
-			return err
+			c.logger.Error(err.Error())
 		}
 	}
 	return nil


### PR DESCRIPTION
Let's not break on errors, and just proceed. The idea is that `scrapedumper` will try its best to dump data, it doesn't really care if it fails.

We also fix a data bug -- we need to add `TRAIN_ID` to our `SortKey` in order to ensure that our PrimaryKey + SortKey is unique across all rows.  There can be multiple trains w/ the same event time for the same station, so this accounts for that.

**NOTE** We should probably add retryers around the dynamo client, and maybe a circuit breaker in the worker, or at least an option for one. 