### PR TITLE
Add a circuit breaker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.coverprofile
+.env
+*-data
+scrapedumper

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Implementing this interface should allow an extensible way to `Dump` data wherev
 - [X] Allow upload to `Dynamo`
 - [X] Allow multiclient response handling for `Dynamo` handler
 - [ ] Use a `Scraper` interface instead of a coupling marta client to it
-- [ ] `circuitbreaker` in the worker?
-- [ ] backoff, jitter, retryer on dynamo client
+- [X] `circuitbreaker` in the worker?
+- [ ] backoff, jitter, retryer on marta client
 
 ## Running
 

--- a/pkg/circuitbreaker/circuit.go
+++ b/pkg/circuitbreaker/circuit.go
@@ -1,0 +1,102 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type CircuitState int
+
+const (
+	Closed   CircuitState = 0
+	Open     CircuitState = 1
+	HalfOpen CircuitState = 2
+)
+
+type BooleanRollingWindow struct {
+	Vals []bool
+	size int
+}
+
+func NewBooleanWindow(size int) *BooleanRollingWindow {
+	vals := make([]bool, size)
+	return &BooleanRollingWindow{
+		vals,
+		size,
+	}
+}
+
+func (r *BooleanRollingWindow) Add(x bool) {
+	if len(r.Vals) >= r.size {
+		r.Vals = r.Vals[1:]
+	}
+
+	r.Vals = append(r.Vals, x)
+}
+
+func (r *BooleanRollingWindow) All(x bool) bool {
+	for _, y := range r.Vals {
+		if x != y {
+			return false
+		}
+	}
+	return true
+}
+
+var (
+	ErrOpenCircuit   = errors.New("circuit is open")
+	ErrSystemFailure = errors.New("poor recovery - half open state reverted back to failure")
+)
+
+type CircuitBreaker struct {
+	state    CircuitState
+	window   *BooleanRollingWindow
+	openedAt time.Time
+	waitTime time.Duration
+	logger   *zap.Logger
+}
+
+func New(logger *zap.Logger, waitTime time.Duration, window int) *CircuitBreaker {
+	return &CircuitBreaker{
+		state:    Closed,
+		window:   NewBooleanWindow(window),
+		waitTime: waitTime,
+		logger:   logger,
+	}
+}
+
+func (c *CircuitBreaker) Run(cmd func() error) error {
+	if c.state == Open {
+		// If enough time has passed, go to a safety state
+		if c.openedAt.Before(time.Now().Add(-c.waitTime)) {
+			c.state = HalfOpen
+		} else {
+			return ErrOpenCircuit
+		}
+	}
+
+	err := cmd()
+	if err != nil {
+		c.window.Add(true)
+		// if we have exceeded our error threshold, open the circuit
+		if c.window.All(true) {
+			// if we are at half open, we are in a system failure state
+			if c.state == HalfOpen {
+				return ErrSystemFailure
+			}
+			c.state = Open
+			c.openedAt = time.Now()
+			return ErrOpenCircuit
+		}
+	} else {
+		c.window.Add(false)
+		// if we are half open, we can revert back to closed if everything is good now
+		if c.window.All(false) && c.state == HalfOpen {
+			c.state = Closed
+		}
+	}
+
+	return nil
+}

--- a/pkg/circuitbreaker/circuit_test.go
+++ b/pkg/circuitbreaker/circuit_test.go
@@ -1,0 +1,133 @@
+package circuitbreaker_test
+
+import (
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	. "github.com/bipol/scrapedumper/pkg/circuitbreaker"
+)
+
+var _ = Describe("Circuit", func() {
+	Context("CircuitBreaker", func() {
+		var (
+			cb       *CircuitBreaker
+			waitTime time.Duration
+			window   int
+		)
+		Context("Run", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				window = 5
+				err = nil
+				cb = New(zap.NewNop(), waitTime, window)
+			})
+
+			When("we fail window size excessively", func() {
+				JustBeforeEach(func() {
+					for i := 0; i < window*2; i++ {
+						err = cb.Run(func() error { return errors.New("") })
+					}
+				})
+				It("returns an open circuit error", func() {
+					Expect(err).To(MatchError(ErrSystemFailure))
+				})
+			})
+			When("we fail window size", func() {
+				JustBeforeEach(func() {
+					for i := 0; i < window-1; i++ {
+						err = cb.Run(func() error { return errors.New("") })
+						Expect(err).To(BeNil())
+					}
+					err = cb.Run(func() error { return errors.New("") })
+				})
+				It("returns an open circuit error", func() {
+					Expect(err).To(MatchError(ErrOpenCircuit))
+				})
+				When("we then recover", func() {
+					JustBeforeEach(func() {
+						for i := 0; i < window; i++ {
+							err = cb.Run(func() error { return nil })
+							Expect(err).To(BeNil())
+						}
+					})
+					It("returns a half open circuit", func() {
+						Expect(err).To(BeNil())
+					})
+				})
+			})
+		})
+	})
+	Context("BooleanRollingWindow", func() {
+		var (
+			bw   *BooleanRollingWindow
+			size int
+		)
+		Context("All", func() {
+			var (
+				b bool
+				s bool
+			)
+			BeforeEach(func() {
+				size = 2
+				bw = NewBooleanWindow(size)
+			})
+			JustBeforeEach(func() {
+				b = bw.All(s)
+			})
+			When("we search for false", func() {
+				When("with a value", func() {
+					BeforeEach(func() {
+						bw.Add(true)
+					})
+					It("returns true", func() {
+						Expect(b).To(BeFalse())
+					})
+				})
+
+				When("we have no values", func() {
+					BeforeEach(func() {
+						s = false
+					})
+					It("returns false", func() {
+						Expect(b).To(BeTrue())
+					})
+				})
+			})
+		})
+		Context("Add", func() {
+			When("we exceed the size", func() {
+				BeforeEach(func() {
+					size = 2
+					bw = NewBooleanWindow(size)
+				})
+				JustBeforeEach(func() {
+					bw.Add(true)
+					bw.Add(true)
+					bw.Add(false)
+				})
+				It("wraps around", func() {
+					Expect(bw.Vals).To(ConsistOf(true, false))
+				})
+			})
+			When("we add values", func() {
+				JustBeforeEach(func() {
+					bw.Add(true)
+				})
+				BeforeEach(func() {
+					size = 5
+					bw = NewBooleanWindow(size)
+				})
+				It("adds the value", func() {
+					Expect(bw.Vals).To(ConsistOf(false, false, false, false, true))
+				})
+			})
+		})
+	})
+
+})

--- a/pkg/circuitbreaker/circuitbreaker.coverprofile
+++ b/pkg/circuitbreaker/circuitbreaker.coverprofile
@@ -1,0 +1,22 @@
+mode: atomic
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:23.55,29.2 2 7
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:31.44,32.27 1 30
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:36.2,36.28 1 30
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:32.27,34.3 1 30
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:39.49,40.27 1 27
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:45.2,45.13 1 10
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:40.27,41.13 1 65
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:41.13,43.4 1 17
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:61.82,68.2 1 3
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:70.54,71.21 1 25
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:80.2,81.16 2 25
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:101.2,101.12 1 17
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:71.21,73.53 1 2
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:73.53,75.4 1 2
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:75.9,77.4 1 0
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:81.16,84.25 2 20
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:84.25,86.27 1 8
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:89.4,91.25 3 3
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:86.27,88.5 1 5
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:93.8,96.49 2 5
+github.com/bipol/scrapedumper/pkg/circuitbreaker/circuit.go:96.49,98.4 1 1

--- a/pkg/circuitbreaker/circuitbreaker_suite_test.go
+++ b/pkg/circuitbreaker/circuitbreaker_suite_test.go
@@ -1,0 +1,13 @@
+package circuitbreaker_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCircuitbreaker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Circuitbreaker Suite")
+}

--- a/pkg/dumper/dump.go
+++ b/pkg/dumper/dump.go
@@ -158,6 +158,7 @@ func (c DynamoDumpHandler) Dump(ctx context.Context, r io.Reader, path string) e
 	for _, i := range inps {
 		_, err = c.dyn.BatchWriteItemWithContext(ctx, i)
 		if err != nil {
+			c.logger.Error(fmt.Sprintf("%+v", i.RequestItems))
 			return err
 		}
 	}

--- a/pkg/worker/client.go
+++ b/pkg/worker/client.go
@@ -61,6 +61,8 @@ func WithCircuitBreaker(c *circuitbreaker.CircuitBreaker) func(*ScrapeAndDumpCli
 	}
 }
 
+// New will initialize a new ScrapeDumper client, and if not provided with a circuit breaker, will fail immediately on the first error
+//is is adviced to provide a circuitbreaker to manage this logic if you would rather this not occur
 func New(pollTime time.Duration, logger *zap.Logger, workList WorkGetter, opts ...Option) ScrapeAndDumpClient {
 	sc := ScrapeAndDumpClient{
 		workList: workList,


### PR DESCRIPTION
Instead of not returning errors in the normal case, this PR adds a `circuitbreaker` so that we can manage when to fail out. 

- [x] Update readme
- [x] add documentation to circuitbreaker implementation