### PR TITLE
Make SortKey comparable

### DIFF
--- a/pkg/martaapi/dynamohelpers.go
+++ b/pkg/martaapi/dynamohelpers.go
@@ -16,7 +16,7 @@ func ScheduleToWriteRequest(s Schedule, t string) (*dynamodb.WriteRequest, error
 		return nil, err
 	}
 	s.PrimaryKey = fmt.Sprintf("%s_%s_%s", s.Station, s.Destination, date.Format("2006-01-02"))
-	s.SortKey = fmt.Sprintf("%s_%s", s.EventTime, s.TrainID)
+	s.SortKey = fmt.Sprintf("%s_%s", date.Format(time.RFC3339), s.TrainID)
 	s.TTL = time.Now().Add(30 * 24 * time.Hour).Unix()
 	attr, err := dynamodbattribute.MarshalMap(s)
 	if err != nil {

--- a/pkg/martaapi/dynamohelpers_test.go
+++ b/pkg/martaapi/dynamohelpers_test.go
@@ -109,6 +109,7 @@ var _ = Describe("Dynamohelpers", func() {
 				Expect(err).To(BeNil())
 				Expect(time.Unix(i, 0)).To(BeTemporally("~", time.Now().Add(30*24*time.Hour), time.Hour))
 				Expect(item).To(MatchKeys(IgnoreExtras, Keys{
+					"SortKey":         PointTo(MatchFields(IgnoreExtras, Fields{"S": Equal(aws.String("2019-05-14T17:50:52Z_train_id"))})),
 					"STATION":         PointTo(MatchFields(IgnoreExtras, Fields{"S": Equal(aws.String("station"))})),
 					"WAITING_SECONDS": PointTo(MatchFields(IgnoreExtras, Fields{"S": Equal(aws.String("-10"))})),
 					"WAITING_TIME":    PointTo(MatchFields(IgnoreExtras, Fields{"S": Equal(aws.String("Boarding"))})),


### PR DESCRIPTION
I have stupidly left our sort key in an incomparable state.  by using `RFC3339` i'll be able to make easier `SortKey` comparisons against `AM` and `PM` times.  e.g. `12 AM` > `11 PM` -- which isn't correct with time.