### PR TITLE
Fix the date

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.0.2 // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.3.0 // indirect
 	go.uber.org/atomic v1.4.0 // indirect

--- a/pkg/circuitbreaker/circuit.go
+++ b/pkg/circuitbreaker/circuit.go
@@ -1,8 +1,9 @@
 package circuitbreaker
 
 import (
-	"errors"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"go.uber.org/zap"
 )
@@ -91,7 +92,7 @@ func (c *CircuitBreaker) Run(cmd func() error) error {
 		if c.window.All(true) {
 			// if we are at half open, we are in a system failure state
 			if c.state == HalfOpen {
-				return ErrSystemFailure
+				return errors.Wrap(ErrSystemFailure, err.Error())
 			}
 			c.state = Open
 			c.openedAt = time.Now()

--- a/pkg/circuitbreaker/circuit_test.go
+++ b/pkg/circuitbreaker/circuit_test.go
@@ -1,8 +1,9 @@
 package circuitbreaker_test
 
 import (
-	"errors"
 	"time"
+
+	"github.com/pkg/errors"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -35,7 +36,7 @@ var _ = Describe("Circuit", func() {
 					}
 				})
 				It("returns an open circuit error", func() {
-					Expect(err).To(MatchError(ErrSystemFailure))
+					Expect(errors.Cause(err)).To(MatchError(ErrSystemFailure))
 				})
 			})
 			When("we fail window size", func() {

--- a/pkg/martaapi/dynamohelpers.go
+++ b/pkg/martaapi/dynamohelpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ScheduleToWriteRequest(s Schedule, t string) (*dynamodb.WriteRequest, error) {
-	date, err := time.Parse("1/02/2006 3:04:05 PM", s.EventTime)
+	date, err := time.Parse("1/2/2006 3:04:05 PM", s.EventTime)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/worker/client.go
+++ b/pkg/worker/client.go
@@ -93,7 +93,6 @@ func (c ScrapeAndDumpClient) Poll(ctx context.Context, errC chan error) {
 			if c.cb != nil {
 				err = c.cb.Run(func() error { return c.scrapeAndDump(ctx) })
 				if err != nil && err == circuitbreaker.ErrSystemFailure {
-					c.logger.Error(err.Error())
 					errC <- err
 					return
 				}

--- a/pkg/worker/client.go
+++ b/pkg/worker/client.go
@@ -93,6 +93,7 @@ func (c ScrapeAndDumpClient) Poll(ctx context.Context, errC chan error) {
 			if c.cb != nil {
 				err = c.cb.Run(func() error { return c.scrapeAndDump(ctx) })
 				if err != nil && err == circuitbreaker.ErrSystemFailure {
+					c.logger.Error(err.Error())
 					errC <- err
 					return
 				}

--- a/pkg/worker/client.go
+++ b/pkg/worker/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bipol/scrapedumper/pkg/circuitbreaker"
 	"github.com/bipol/scrapedumper/pkg/dumper"
 	"github.com/bipol/scrapedumper/pkg/martaapi"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -92,7 +93,7 @@ func (c ScrapeAndDumpClient) Poll(ctx context.Context, errC chan error) {
 			var err error
 			if c.cb != nil {
 				err = c.cb.Run(func() error { return c.scrapeAndDump(ctx) })
-				if err != nil && err == circuitbreaker.ErrSystemFailure {
+				if err != nil && errors.Cause(err) == circuitbreaker.ErrSystemFailure {
 					errC <- err
 					return
 				}


### PR DESCRIPTION
Really poor assumption by me to think that the day date was zero padded -- looks like it isn't :(.   Easy fix!

Also added error logging because I should probably do that.

Also:
```
{
  "level": "error",
  "ts": 1562712714.15019,
  "caller": "scrapedumper/main.go:96",
  "msg": "poor recovery - half open state reverted back to failure",
  "stacktrace": "main.main\n\t/Users/bipol/repos/scrapedumper/main.go:96\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:201"
}
``` 
to
```
{
  "level": "error",
  "ts": 1562713317.917614,
  "caller": "scrapedumper/main.go:96",
  "msg": "parsing time \"7/9/2019 7:01:07 PM\" as \"1/02/2006 3:04:05 PM\": cannot parse \"9/2019 7:01:07 PM\" as \"02\": poor recovery - half open state reverted back to failure",
  "stacktrace": "main.main\n\t/Users/bipol/repos/scrapedumper/main.go:96\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:201"
}
```