### PR TITLE
Use Environments if Set By Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,38 @@ Implementing this interface should allow an extensible way to `Dump` data wherev
 ## Running
 
 After running `go build` to obtain the binary, you can run the binary as long as you provide the required environment variables:
-```
+```golang
 type options struct {
 	OutputLocation    string `long:"output-location" env:"OUTPUT_LOCATION" description:"local path to output"`
+	DynamoTableName   string `long:"dynamo-table-name" env:"DYNAMO_TABLE_NAME" description:"dynamo table name"`
 	S3BucketName      string `long:"s3-bucket-name" env:"S3_BUCKET_NAME" description:"s3 bucket to dump stuff into"`
 	MartaAPIKey       string `long:"marta-api-key" env:"MARTA_API_KEY" description:"marta api key" required:"true"`
 	PollTimeInSeconds int    `long:"poll-time-in-seconds" env:"POLL_TIME_IN_SECONDS" description:"time to poll marta api every second" required:"true"`
+
+	ConfigPath *string `long:"config-path" env:"CONFIG_PATH" description:"An optional file that overrides the default configuration of sources and targets."`
 }
 ```
 
 `./scrapedumper --output-location=. --marta-api-key={{key}} --poll-time-in-seconds=15`
+
+### Config Based Approach
+```json
+{
+	"bus_dumper": {
+		"kind": "ROUND_ROBIN | FILE | S3 | DYNAMODB",
+		"components": [],
+		"s3_bucket_name": "",
+		"dynamo_table_name": "",
+		"local_output_location": ""
+	},
+	"train_dumper": {
+		"kind": "ROUND_ROBIN | FILE | S3 | DYNAMODB",
+		"components": [],
+		"s3_bucket_name": "",
+		"dynamo_table_name": "",
+		"local_output_location": ""
+	}
+}
+```
+
+`./scrapedumper --config-path=./config --marta-api-key={{key}} --poll-time-in-seconds=15`

--- a/main.go
+++ b/main.go
@@ -107,8 +107,11 @@ func GetWorkConfig(opts options) (wc config.WorkConfig, err error) {
 
 //BuildDefaultWorkConfig produces the default collection of dumpers
 func BuildDefaultWorkConfig(opts options) config.WorkConfig {
-	var dumpConfig []config.DumpConfig
-	var busConfig []config.DumpConfig
+	var (
+		dumpConfig []config.DumpConfig
+		busConfig  []config.DumpConfig
+		cfg        config.WorkConfig
+	)
 	if opts.S3BucketName != "" {
 		dumpConfig = append(dumpConfig,
 			config.DumpConfig{
@@ -145,14 +148,18 @@ func BuildDefaultWorkConfig(opts options) config.WorkConfig {
 			},
 		)
 	}
-	return config.WorkConfig{
-		TrainDumper: config.DumpConfig{
+	if len(dumpConfig) != 0 {
+		cfg.TrainDumper = config.DumpConfig{
 			Kind:       config.RoundRobinKind,
 			Components: dumpConfig,
-		},
-		BusDumper: config.DumpConfig{
+		}
+	}
+	if len(busConfig) != 0 {
+		cfg.BusDumper = config.DumpConfig{
 			Kind:       config.RoundRobinKind,
 			Components: busConfig,
-		},
+		}
+
 	}
+	return cfg
 }

--- a/main.go
+++ b/main.go
@@ -149,13 +149,13 @@ func BuildDefaultWorkConfig(opts options) config.WorkConfig {
 		)
 	}
 	if len(dumpConfig) != 0 {
-		cfg.TrainDumper = config.DumpConfig{
+		cfg.TrainDumper = &config.DumpConfig{
 			Kind:       config.RoundRobinKind,
 			Components: dumpConfig,
 		}
 	}
 	if len(busConfig) != 0 {
-		cfg.BusDumper = config.DumpConfig{
+		cfg.BusDumper = &config.DumpConfig{
 			Kind:       config.RoundRobinKind,
 			Components: busConfig,
 		}

--- a/main.go
+++ b/main.go
@@ -107,36 +107,52 @@ func GetWorkConfig(opts options) (wc config.WorkConfig, err error) {
 
 //BuildDefaultWorkConfig produces the default collection of dumpers
 func BuildDefaultWorkConfig(opts options) config.WorkConfig {
+	var dumpConfig []config.DumpConfig
+	var busConfig []config.DumpConfig
+	if opts.S3BucketName != "" {
+		dumpConfig = append(dumpConfig,
+			config.DumpConfig{
+				Kind:         config.S3DumperKind,
+				S3BucketName: opts.S3BucketName,
+			},
+		)
+		busConfig = append(busConfig,
+			config.DumpConfig{
+				Kind:         config.S3DumperKind,
+				S3BucketName: opts.S3BucketName,
+			},
+		)
+	}
+	if opts.OutputLocation != "" {
+		dumpConfig = append(dumpConfig,
+			config.DumpConfig{
+				Kind:                config.FileDumperKind,
+				LocalOutputLocation: opts.OutputLocation,
+			},
+		)
+		busConfig = append(busConfig,
+			config.DumpConfig{
+				Kind:         config.S3DumperKind,
+				S3BucketName: opts.S3BucketName,
+			},
+		)
+	}
+	if opts.DynamoTableName != "" {
+		dumpConfig = append(dumpConfig,
+			config.DumpConfig{
+				Kind:            config.DynamoDBDumperKind,
+				DynamoTableName: opts.DynamoTableName,
+			},
+		)
+	}
 	return config.WorkConfig{
 		TrainDumper: config.DumpConfig{
-			Kind: config.RoundRobinKind,
-			Components: []config.DumpConfig{
-				config.DumpConfig{
-					Kind:         config.S3DumperKind,
-					S3BucketName: opts.S3BucketName,
-				},
-				config.DumpConfig{
-					Kind:                config.FileDumperKind,
-					LocalOutputLocation: opts.OutputLocation,
-				},
-				config.DumpConfig{
-					Kind:            config.DynamoDBDumperKind,
-					DynamoTableName: opts.DynamoTableName,
-				},
-			},
+			Kind:       config.RoundRobinKind,
+			Components: dumpConfig,
 		},
 		BusDumper: config.DumpConfig{
-			Kind: config.RoundRobinKind,
-			Components: []config.DumpConfig{
-				config.DumpConfig{
-					Kind:         config.S3DumperKind,
-					S3BucketName: opts.S3BucketName,
-				},
-				config.DumpConfig{
-					Kind:                config.FileDumperKind,
-					LocalOutputLocation: opts.OutputLocation,
-				},
-			},
+			Kind:       config.RoundRobinKind,
+			Components: busConfig,
 		},
 	}
 }

--- a/pkg/config/worklist.go
+++ b/pkg/config/worklist.go
@@ -10,8 +10,8 @@ import (
 //WorkConfig is the top-level config object, defined an entire
 //scrapedumper job to be started.
 type WorkConfig struct {
-	BusDumper   DumpConfig `json:"bus_dumper"`
-	TrainDumper DumpConfig `json:"train_dumper"`
+	BusDumper   *DumpConfig `json:"bus_dumper"`
+	TrainDumper *DumpConfig `json:"train_dumper"`
 }
 
 //BuildWorkList builds a worklist from the specified clients
@@ -22,21 +22,22 @@ func BuildWorkList(
 	busClient martaapi.Client,
 	trainClient martaapi.Client,
 ) (workList worker.WorkList, err error) {
-	busDumper, err := BuildDumper(log, c.BusDumper)
-	if err != nil {
-		err = errors.Wrap(err, "failed to build bus dumper")
-		return
+	if c.BusDumper != nil {
+		busDumper, err := BuildDumper(log, *c.BusDumper)
+		if err != nil {
+			err = errors.Wrap(err, "failed to build bus dumper")
+			return workList, err
+		}
+		workList.AddWork(busClient, busDumper)
 	}
 
-	trainDumper, err := BuildDumper(log, c.TrainDumper)
-	if err != nil {
-		err = errors.Wrap(err, "failed to build train dumper")
-		return
+	if c.TrainDumper != nil {
+		trainDumper, err := BuildDumper(log, *c.TrainDumper)
+		if err != nil {
+			err = errors.Wrap(err, "failed to build train dumper")
+			return workList, err
+		}
+		workList.AddWork(trainClient, trainDumper)
 	}
-
-	workList.
-		AddWork(trainClient, trainDumper).
-		AddWork(busClient, busDumper)
-
 	return
 }

--- a/pkg/config/worklist_test.go
+++ b/pkg/config/worklist_test.go
@@ -18,11 +18,11 @@ var _ = Describe("BuildWorkList", func() {
 	)
 
 	BeforeEach(func() {
-		cfg.BusDumper = config.DumpConfig{
+		cfg.BusDumper = &config.DumpConfig{
 			Kind:         config.S3DumperKind,
 			S3BucketName: "my-bucket",
 		}
-		cfg.TrainDumper = config.DumpConfig{
+		cfg.TrainDumper = &config.DumpConfig{
 			Kind:         config.S3DumperKind,
 			S3BucketName: "my-bucket",
 		}


### PR DESCRIPTION
This PR will use environment variables if they are set, by default.

This accounts for situations in which a user does not provide a `config` file, such as in the case of when we deploy to heroku.  

Still need to write some documentation for this pupper.

**Note** -- In draft, might be worthy of a discussion to find better ways to do this.

https://github.com/spf13/viper ?

- [x] Write documentation