### PR TITLE
try to avoid leaving file artifacts for unsuccessful requests

### DIFF
--- a/.golangci-lint.yaml
+++ b/.golangci-lint.yaml
@@ -1,0 +1,5 @@
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck

--- a/.golangci-lint.yaml
+++ b/.golangci-lint.yaml
@@ -1,5 +1,5 @@
 issues:
   exclude-rules:
-    - path: \*_test\.go
+    - path: _test\.go
       linters:
         - errcheck

--- a/.golangci-lint.yaml
+++ b/.golangci-lint.yaml
@@ -1,5 +1,5 @@
 issues:
   exclude-rules:
-    - path: *_test\.go
+    - path: \*_test\.go
       linters:
         - errcheck

--- a/.golangci-lint.yaml
+++ b/.golangci-lint.yaml
@@ -1,5 +1,5 @@
 issues:
   exclude-rules:
-    - path: _test\.go
+    - path: *_test\.go
       linters:
         - errcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - go install github.com/onsi/gomega/...     # fetches the matcher library
 
 script:
-  - golangci-lint run       # run a bunch of code checkers/linters in parallel
+  - golangci-lint run --config=.golangci-lint.yaml # run a bunch of code checkers/linters in parallel
   - ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover --trace --race --progress
   - GOOS=linux go build # target the container environment
 

--- a/pkg/dumper/dump.go
+++ b/pkg/dumper/dump.go
@@ -85,6 +85,11 @@ func (c LocalDumpHandler) Dump(ctx context.Context, r io.Reader, path string) er
 
 	_, err = io.Copy(f, r)
 	if err != nil {
+		//avoid leaving a ,malformed JSON file behind if possible
+		if f.Close() == nil {
+			c.fs.Remove(f.Name())
+		}
+
 		return err
 	}
 

--- a/pkg/dumper/dump.go
+++ b/pkg/dumper/dump.go
@@ -87,7 +87,9 @@ func (c LocalDumpHandler) Dump(ctx context.Context, r io.Reader, path string) er
 	if err != nil {
 		//avoid leaving a ,malformed JSON file behind if possible
 		if f.Close() == nil {
-			c.fs.Remove(f.Name())
+			if rErr := c.fs.Remove(f.Name()); rErr != nil {
+				err = rErr
+			}
 		}
 
 		return err

--- a/pkg/dumper/dump.go
+++ b/pkg/dumper/dump.go
@@ -85,7 +85,7 @@ func (c LocalDumpHandler) Dump(ctx context.Context, r io.Reader, path string) er
 
 	_, err = io.Copy(f, r)
 	if err != nil {
-		//avoid leaving a ,malformed JSON file behind if possible
+		//avoid leaving a malformed JSON file behind if possible
 		if f.Close() == nil {
 			if rErr := c.fs.Remove(f.Name()); rErr != nil {
 				err = rErr

--- a/pkg/dumper/dump_test.go
+++ b/pkg/dumper/dump_test.go
@@ -112,6 +112,16 @@ var _ = Describe("Dump", func() {
 				Expect(err).To(BeNil())
 			})
 		})
+		When("it fails to copy", func() {
+			BeforeEach(func() {
+				var w *io.PipeWriter
+				r, w = io.Pipe()
+				w.CloseWithError(errors.New("broken pipe"))
+			})
+			It("returns an error", func() {
+				Expect(err).To(HaveOccurred())
+			})
+		})
 	})
 	Context("DynamoDumpHandler", func() {
 		var (

--- a/pkg/dumper/dump_test.go
+++ b/pkg/dumper/dump_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Dump", func() {
 			BeforeEach(func() {
 				var w *io.PipeWriter
 				r, w = io.Pipe()
-				w.CloseWithError(errors.New("broken pipe")) //nolint:errcheck
+				w.CloseWithError(errors.New("broken pipe"))
 			})
 			It("returns an error", func() {
 				Expect(err).To(HaveOccurred())

--- a/pkg/dumper/dump_test.go
+++ b/pkg/dumper/dump_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Dump", func() {
 			BeforeEach(func() {
 				var w *io.PipeWriter
 				r, w = io.Pipe()
-				w.CloseWithError(errors.New("broken pipe"))
+				w.CloseWithError(errors.New("broken pipe")) //nolint:errcheck
 			})
 			It("returns an error", func() {
 				Expect(err).To(HaveOccurred())

--- a/pkg/martaapi/client.go
+++ b/pkg/martaapi/client.go
@@ -2,6 +2,7 @@ package martaapi
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -91,5 +92,10 @@ func (c Client) FindSchedules(ctx context.Context) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request to the MARTA API failed with status `%v`", resp.StatusCode)
+	}
+
 	return resp.Body, nil
 }

--- a/pkg/martaapi/client_test.go
+++ b/pkg/martaapi/client_test.go
@@ -2,6 +2,8 @@ package martaapi_test
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io/ioutil"
 	"net/http"
 
@@ -48,8 +50,28 @@ var _ = Describe("Client", func() {
 	Context("New", func() {
 		When("called", func() {
 			It("does not return an err", func() {
-				Expect(err).To(BeNil())
 				Expect(client).ToNot(BeNil())
+			})
+		})
+	})
+	Context("FindSchedules", func() {
+		JustBeforeEach(func() {
+			_, err = client.FindSchedules(context.Background())
+		})
+		When("the doer fails", func() {
+			BeforeEach(func() {
+				doer.DoReturns(nil, errors.New("do failed"))
+			})
+			It("fails", func() {
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		When("the request receives a non-normal error code", func() {
+			BeforeEach(func() {
+				doer.DoReturns(&http.Response{StatusCode: http.StatusBadGateway}, nil)
+			})
+			It("fails", func() {
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/worker/client.go
+++ b/pkg/worker/client.go
@@ -90,7 +90,13 @@ func (c ScrapeAndDumpClient) Poll(ctx context.Context, errC chan error) {
 			}
 			var err error
 			if c.cb != nil {
-				err = c.cb.Run(func() error { return c.scrapeAndDump(ctx) })
+				err = c.cb.Run(func() error {
+					innerErr := c.scrapeAndDump(ctx)
+					if innerErr != nil {
+						c.logger.Error(innerErr.Error())
+					}
+					return innerErr
+				})
 				if err != nil && errors.Cause(err) == circuitbreaker.ErrSystemFailure {
 					errC <- err
 					return


### PR DESCRIPTION
While trying to load my existing cache of JSON files into postgres, I found that a few contained HTTP error documents and a couple were empty. Only about 6 out of tens of thousands, but I thought I'd add a small effort to avoid creating those artifacts